### PR TITLE
fix some typos

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-xdg=${${XDG_DATA_HOME}:-${HOME}/.local/share}
-DIRECTORY="${xdg}/rofi/themes/}"
+xdg=${XDG_DATA_HOME:-${HOME}/.local/share}
+DIRECTORY="${xdg}/rofi/themes/"
 
 if [ ! -d "${DIRECTORY}" ]
 then


### PR DESCRIPTION
Some overlooked typos near the top of install.sh were causing it to crash before installing any themes.